### PR TITLE
feat: Enhance footer with LinkedIn link and copyright

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,13 +1,27 @@
 ---
 import { getI18N } from '@/i18n'
+import LinkedIn from '@/components/icons/LinkedIn.astro';
 
 const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })
+const currentYear = new Date().getFullYear();
 ---
 
 <footer class='relative bg-background px-4 py-8 text-center text-xs'>
-  <p>
+  <a
+    href="https://www.linkedin.com/in/diego-de-sousa"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="LinkedIn Profile"
+    class="mb-2 inline-block"
+  >
+    <LinkedIn class="h-6 w-6 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" />
+  </a>
+  <p class="mb-2">
     {i18n.FOOTER.COPY.SEASONSCHANGE}
+  </p>
+  <p>
+    &copy; {currentYear} Diego de Sousa. {i18n.FOOTER.COPYRIGHT}
   </p>
   {
     //   <p>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -73,7 +73,8 @@
 	},
 	"FOOTER": {
 		"COPY": {
-			"SEASONSCHANGE": "Fun fact: like me, this website changes with the seasons and time of day. 🌱🌞🍂❄️"
+			"SEASONSCHANGE": "Fun fact: like me, this website changes with the seasons and time of day. 🌱🌞🍂❄️",
+			"COPYRIGHT": "All rights reserved."
 		}
 	}
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -73,7 +73,8 @@
 	},
 	"FOOTER": {
 		"COPY": {
-			"SEASONSCHANGE": "Una curiosidad: como yo, esta web cambia según las estaciones del año y la hora del día. 🌱🌞🍂❄️"
+			"SEASONSCHANGE": "Dato curioso: al igual que yo, esta web cambia según las estaciones y el momento del día. 🌱🌞🍂❄️",
+			"COPYRIGHT": "Todos los derechos reservados."
 		}
 	}
 }

--- a/src/i18n/gl.json
+++ b/src/i18n/gl.json
@@ -73,7 +73,8 @@
 	},
 	"FOOTER": {
 		"COPY": {
-			"SEASONSCHANGE": "Unha curiosidade: como eu, esta web cambia segundo as estacións do ano e a hora do día. 🌱🌞🍂❄️"
+			"SEASONSCHANGE": "Unha curiosidade: coma min, esta web cambia segundo as estacións e a hora do día. 🌱🌞🍂❄️",
+			"COPYRIGHT": "Tódolos dereitos reservados."
 		}
 	}
 }

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -73,7 +73,8 @@
 	},
 	"FOOTER": {
 		"COPY": {
-			"SEASONSCHANGE": "Uma curiosidade: tal como eu, este site muda com as estações do ano e a hora do dia. 🌱🌞🍂❄️"
+			"SEASONSCHANGE": "Uma curiosidade: assim como eu, este site muda de acordo com as estações e a hora do dia. 🌱🌞🍂❄️",
+			"COPYRIGHT": "Todos os direitos reservados."
 		}
 	}
 }


### PR DESCRIPTION
Adds a LinkedIn icon and link to the footer, allowing you to easily access the owner's LinkedIn profile.

Also adds a dynamic copyright notice to the footer, including the current year and the site owner's name.

Includes internationalization for the new copyright text in English, Spanish, Galician, and Portuguese.